### PR TITLE
remove ontology URI workaround

### DIFF
--- a/cubi_isa_templates/isatab-mass_cytometry/cookiecutter.json
+++ b/cubi_isa_templates/isatab-mass_cytometry/cookiecutter.json
@@ -19,9 +19,9 @@
     "Other"
   ],
   "_material_ncit": {
-    "Cell line": "%23C16403",
-    "Organoid": "%23C172259",
-    "PBMC sample": "%23C178965"
+    "Cell line": "#C16403",
+    "Organoid": "#C172259",
+    "PBMC sample": "#C178965"
   },
   "tissue": [
     "No",
@@ -29,7 +29,7 @@
     "Other"
   ],
   "_tissue_ncit": {
-    "Intestinal epithelium": "%23C49240"
+    "Intestinal epithelium": "#C49240"
   },
   "source_characteristics": "Origin,Passage",
   "sample_suffixes": "sample1,sample2",

--- a/cubi_isa_templates/isatab-somatic/cookiecutter.json
+++ b/cubi_isa_templates/isatab-somatic/cookiecutter.json
@@ -12,12 +12,12 @@
     "Benign Neoplasm"
   ],
   "_neoplasm_terms": {
-    "Primary Neoplasm": "%23C8509",
-    "Secondary Neoplasm": "%23C36255",
-    "Recurrent Neoplasm": "%23C4798",
-    "Metastatic Neoplasm": "%23C3261",
-    "Refractory Neoplasm": "%23C7628",
-    "Benign Neoplasm": "%23C3677"
+    "Primary Neoplasm": "#C8509",
+    "Secondary Neoplasm": "#C36255",
+    "Recurrent Neoplasm": "#C4798",
+    "Metastatic Neoplasm": "#C3261",
+    "Refractory Neoplasm": "#C7628",
+    "Benign Neoplasm": "#C3677"
   },
   "measurement_type": [
     "exome sequencing",


### PR DESCRIPTION
After bihealth/sodar-server#1762 was fixed we need to remove this workaround or the ontology URL will break.