### PR TITLE
fix: Library prefix is called Fastq prefix in assays file

### DIFF
--- a/cubi_isa_templates/isatab-single_cell_rnaseq/{{cookiecutter.__output_dir}}/i_Investigation.txt
+++ b/cubi_isa_templates/isatab-single_cell_rnaseq/{{cookiecutter.__output_dir}}/i_Investigation.txt
@@ -79,7 +79,7 @@ Study Protocol Type Term Source REF	""	""	""	""
 Study Protocol Description	""	""	""	""
 Study Protocol URI	""	""	""	""
 Study Protocol Version	""	""	""	""
-Study Protocol Parameters Name	Method	Dissociation method;Cell count{% for meta in dissociation_meta -%};{{meta}}{% endfor %}	Library kit;Library type;Multiplex genotype;Multiplex sample;Multiplex oligo{% for meta in library_construction_meta -%};{{meta}}{% endfor %}	Sequencing batch;Library prefix;Barcode kit;Barcode name{% for meta in sequencing_meta -%};{{meta}}{% endfor %}
+Study Protocol Parameters Name	Method	Dissociation method;Cell count{% for meta in dissociation_meta -%};{{meta}}{% endfor %}	Library kit;Library type;Multiplex genotype;Multiplex sample;Multiplex oligo{% for meta in library_construction_meta -%};{{meta}}{% endfor %}	Sequencing batch;Fastq prefix;Barcode kit;Barcode name{% for meta in sequencing_meta -%};{{meta}}{% endfor %}
 Study Protocol Parameters Name Term Accession Number	""	";{% for meta in dissociation_meta -%};{% endfor %}"	";;;;{% for meta in library_construction_meta -%};{% endfor %}"	";;;{% for meta in sequencing_meta -%};{% endfor %}"
 Study Protocol Parameters Name Term Source REF	""	";{% for meta in dissociation_meta -%};{% endfor %}"	";;;;{% for meta in library_construction_meta -%};{% endfor %}"	";;;{% for meta in sequencing_meta -%};{% endfor %}"
 Study Protocol Components Name	""	""	""	""


### PR DESCRIPTION
Inconsistency in parameter naming. `Library prefix` in investigation file and `Fastq prefix` in assay file. If I recall correctly the name was changed recently to better reflect what is supposed to go in this column. The stem cell core sc template uses `Fastq prefix`.

Calling @mmilek and @Nicolai-vKuegelgen to review to see who's faster.