### PR TITLE
fix: File name slash sanitization (#37)

### DIFF
--- a/cubi_isa_templates/isatab-bulk_rnaseq/cookiecutter.json
+++ b/cubi_isa_templates/isatab-bulk_rnaseq/cookiecutter.json
@@ -9,7 +9,7 @@
   "center_contact": "",
 
   "study_title": "{{cookiecutter.investigation_title}}",
-  "s_file_name": "{{cookiecutter.investigation_title|replace(' ', '_')}}",
+  "s_file_name": "{{cookiecutter.investigation_title|replace(' ', '_')|replace('/', '_')}}",
   "assay_prefix": "{{cookiecutter.s_file_name|lower}}",
   "a_technology_type": "nucleotide sequencing",
   "assay_name": "{{cookiecutter.a_measurement_type|replace(' ', '_')}}_{{cookiecutter.a_technology_type|replace(' ', '_')}}",

--- a/cubi_isa_templates/isatab-generic/cookiecutter.json
+++ b/cubi_isa_templates/isatab-generic/cookiecutter.json
@@ -46,7 +46,7 @@
   "center_contact": "",
 
   "study_title": "{{cookiecutter.investigation_title}}",
-  "s_file_name": "{{cookiecutter.investigation_title|replace(' ', '_')}}",
+  "s_file_name": "{{cookiecutter.investigation_title|replace(' ', '_')|replace('/', '_')}}",
   "assay_prefix": "{{cookiecutter.s_file_name|lower}}",
   "a_measurement_abbreviation": "{% if cookiecutter.a_measurement_type == 'transcription profiling' %}mRNA_seq{% else %}UNKNOWN{% endif %}",
   "assay_name": "{{cookiecutter.a_measurement_type|replace(' ', '_')}}_{{cookiecutter.a_technology_type|replace(' ', '_')}}",

--- a/cubi_isa_templates/isatab-germline/cookiecutter.json
+++ b/cubi_isa_templates/isatab-germline/cookiecutter.json
@@ -1,7 +1,7 @@
 {
   "investigation_title": "Investigation Title",
   "study_title": "{{cookiecutter.investigation_title}}",
-  "s_file_name": "{{cookiecutter.investigation_title|replace(' ', '_')|lower}}",
+  "s_file_name": "{{cookiecutter.investigation_title|replace(' ', '_')|replace('/', '_')|lower}}",
   "source_names": "index,mother,father",
   "measurement_type": [
       "exome sequencing",

--- a/cubi_isa_templates/isatab-mass_cytometry/cookiecutter.json
+++ b/cubi_isa_templates/isatab-mass_cytometry/cookiecutter.json
@@ -38,7 +38,7 @@
   "sample_factor_types": "intracellular structure,chemical compound,time span",
   "dissociation_type": ["No", "pre-fix Trypsin", "post-fix Trypsin", "post-fix Octo"],
   "sample_multiplexing": ["No", "SBT Pd 20-plex", "TOBis 35-plex", "Other"],
-  "__s_file_name": "{{cookiecutter.investigation_identifier|replace(' ', '_')}}",
+  "__s_file_name": "{{cookiecutter.investigation_identifier|replace(' ', '_')|replace('/', '_')}}",
   "__assay_prefix": "{{cookiecutter.__s_file_name}}",
   "__output_dir": "Required variable. Do not remove.",
   "__prompts__": {

--- a/cubi_isa_templates/isatab-microarray/cookiecutter.json
+++ b/cubi_isa_templates/isatab-microarray/cookiecutter.json
@@ -22,11 +22,11 @@
   "array_design_ref": "",
 
   "study_title": "{{cookiecutter.investigation_title}}",
-  "s_file_name": "{{cookiecutter.investigation_title|replace(' ', '_')}}",
+  "s_file_name": "{{cookiecutter.investigation_title|replace(' ', '_')|replace('/', '_')}}",
   "assay_prefix": "{{cookiecutter.s_file_name|lower}}",
   "a_technology_type": "microarray",
   "assay_name": "{{cookiecutter.a_measurement_type|replace(' ', '_')}}_{{cookiecutter.a_technology_type|replace(' ', '_')}}",
-  
+
   "_terms": {
     "transcription profiling": {
       "accession_number": "http://purl.obolibrary.org/obo/OBI_0000424",

--- a/cubi_isa_templates/isatab-ms_meta_biocrates/cookiecutter.json
+++ b/cubi_isa_templates/isatab-ms_meta_biocrates/cookiecutter.json
@@ -2,11 +2,11 @@
   "investigation_title": "Investigation Title",
 
   "study_title": "{{cookiecutter.investigation_title}}",
-  "study_id": "{{cookiecutter.study_title|lower|replace(' ', '_')}}",
+  "study_id": "{{cookiecutter.study_title|lower|replace(' ', '_')|replace('/', '_')}}",
   "study_file_name": "{{cookiecutter.study_id}}",
 
   "sample_names": "alpha,beta,gamma",
-  
+
   "organism": [
     "Homo sapiens",
     "Mus musculus"
@@ -21,7 +21,7 @@
       "taxon": "10090"
     }
   },
-  
+
   "assay_measurement_type": [
     "metabolite profiling"
   ],
@@ -35,7 +35,7 @@
       "accession": "http://purl.obolibrary.org/obo/OBI_0000470"
     }
   },
-  
+
   "biocrates_kit": [
     "Biocrates MxP Quant 500 Kit",
     "Biocrates AbsoluteIDQ p400 HR Kit"

--- a/cubi_isa_templates/isatab-single_cell_rnaseq/cookiecutter.json
+++ b/cubi_isa_templates/isatab-single_cell_rnaseq/cookiecutter.json
@@ -27,7 +27,7 @@
   "sample_multiplexing": ["No", "CellPlex", "TotalSeq", "Other"],
   "genotype_multiplexing": ["no", "yes"],
   "study_title": "{{cookiecutter.investigation_title}}",
-  "s_file_name": "{{cookiecutter.investigation_title|replace(' ', '_')}}",
+  "s_file_name": "{{cookiecutter.investigation_title|replace(' ', '_')|replace('/', '_')}}",
   "assay_prefix": "{{cookiecutter.s_file_name|lower}}",
   "a_technology_type": "nucleotide sequencing",
   "assay_name": "{{cookiecutter.a_measurement_type|replace(' ', '_')}}_{{cookiecutter.a_technology_type|replace(' ', '_')}}",

--- a/cubi_isa_templates/isatab-somatic/cookiecutter.json
+++ b/cubi_isa_templates/isatab-somatic/cookiecutter.json
@@ -1,7 +1,7 @@
 {
   "investigation_title": "Investigation Title",
   "study_title": "{{cookiecutter.investigation_title}}",
-  "s_file_name": "{{cookiecutter.investigation_title|replace(' ', '_')|lower}}",
+  "s_file_name": "{{cookiecutter.investigation_title|replace(' ', '_')|replace('/', '_')|lower}}",
   "source_names": "patient1,patient2",
   "neoplasm_type": [
     "Primary Neoplasm",

--- a/cubi_isa_templates/isatab-stem_cell_core_bulk/cookiecutter.json
+++ b/cubi_isa_templates/isatab-stem_cell_core_bulk/cookiecutter.json
@@ -14,7 +14,7 @@
   "library_construction_meta": "Library selection,Target insert size",
   "sequencing_meta": "Platform,Instrument model,No. targeted reads,Paired-End",
   "s_file_name": "{{cookiecutter.study_title|replace(' ', '_')|replace('/', '-')}}",
-  "assay_prefix": "{{s_file_name}}",
+  "assay_prefix": "{{cookiecutter.s_file_name}}",
   "assay_name": "GEX_{{cookiecutter.a_measurement_type|replace(' ', '_')}}",
   "__output_dir": "Required variable. Do not remove."
 }

--- a/cubi_isa_templates/isatab-stem_cell_core_bulk/cookiecutter.json
+++ b/cubi_isa_templates/isatab-stem_cell_core_bulk/cookiecutter.json
@@ -14,7 +14,7 @@
   "library_construction_meta": "Library selection,Target insert size",
   "sequencing_meta": "Platform,Instrument model,No. targeted reads,Paired-End",
   "s_file_name": "{{cookiecutter.study_title|replace(' ', '_')|replace('/', '-')}}",
-  "assay_prefix": "{{cookiecutter.study_title|replace(' ', '_')|replace('/', '-')}}",
+  "assay_prefix": "{{s_file_name}}",
   "assay_name": "GEX_{{cookiecutter.a_measurement_type|replace(' ', '_')}}",
   "__output_dir": "Required variable. Do not remove."
 }

--- a/cubi_isa_templates/isatab-stem_cell_core_sc/cookiecutter.json
+++ b/cubi_isa_templates/isatab-stem_cell_core_sc/cookiecutter.json
@@ -33,7 +33,7 @@
   "sample_multiplexing": ["No", "CellPlex", "TotalSeq", "Other"],
   "genotype_multiplexing": ["no", "yes"],
   "s_file_name": "{{cookiecutter.study_title|replace(' ', '_')|replace('/', '-')}}",
-  "assay_prefix": "{{s_file_name}}",
+  "assay_prefix": "{{cookiecutter.s_file_name}}",
   "assay_name": "{{cookiecutter.library_type}}_{{cookiecutter.a_measurement_type|replace(' ', '_')}}",
   "__output_dir": "Required variable. Do not remove."
 }

--- a/cubi_isa_templates/isatab-stem_cell_core_sc/cookiecutter.json
+++ b/cubi_isa_templates/isatab-stem_cell_core_sc/cookiecutter.json
@@ -33,7 +33,7 @@
   "sample_multiplexing": ["No", "CellPlex", "TotalSeq", "Other"],
   "genotype_multiplexing": ["no", "yes"],
   "s_file_name": "{{cookiecutter.study_title|replace(' ', '_')|replace('/', '-')}}",
-  "assay_prefix": "{{cookiecutter.study_title|replace(' ', '_')|replace('/', '-')}}",
+  "assay_prefix": "{{s_file_name}}",
   "assay_name": "{{cookiecutter.library_type}}_{{cookiecutter.a_measurement_type|replace(' ', '_')}}",
   "__output_dir": "Required variable. Do not remove."
 }


### PR DESCRIPTION
This is a simple way to hopefully fix crashes from slashes in investigation titles (or identifiers, where used).